### PR TITLE
refactor: modularize Django settings and env configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Django
+SECRET_KEY=your-secret-key
+ALLOWED_HOSTS=localhost,example.com
+
+# Database
+PGDATABASE=artcritique
+PGUSER=postgres
+PGPASSWORD=postgres
+PGHOST=localhost
+PGPORT=5432
+
+# Optional services
+USE_S3=False
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_STORAGE_BUCKET_NAME=
+AWS_S3_REGION_NAME=us-east-2
+
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=

--- a/artcritique/asgi.py
+++ b/artcritique/asgi.py
@@ -14,7 +14,7 @@ from django.core.asgi import get_asgi_application
 
 # Initialize Django ASGI application early to ensure AppRegistry is populated
 # before importing channel routes
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'artcritique.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'artcritique.settings.prod')
 django_asgi_app = get_asgi_application()
 
 # Now import channels components after Django initialization
@@ -33,3 +33,4 @@ application = ProtocolTypeRouter({
         )
     ),
 })
+

--- a/artcritique/settings/__init__.py
+++ b/artcritique/settings/__init__.py
@@ -1,0 +1,2 @@
+from .dev import *
+

--- a/artcritique/settings/base.py
+++ b/artcritique/settings/base.py
@@ -14,26 +14,28 @@ import os
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve().parent.parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-1234567890abcdefghijklmnopqrstuvwxyz'
+# Loaded from environment with a fallback for development
+SECRET_KEY = os.environ.get('SECRET_KEY', 'insecure-development-key')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+# Debug mode defaults to False and can be overridden in env or specific settings
+DEBUG = os.environ.get('DEBUG', 'False') == 'True'
 
-# Allow all hosts
-ALLOWED_HOSTS = ['*', '.replit.app']
+# Allowed hosts can be overridden via environment variable
+ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', '*').split(',')
 
 # Get Replit domain from environment
 REPLIT_DOMAIN = os.environ.get('REPLIT_DOMAIN', '*')
 
 # Configure SSL based on environment variable
-# Forced to False for Replit to work with the load balancer
-SSL_ENABLED = False  # Force SSL off for Replit
+# Forced to False for Replit to work with the load balancer by default
+SSL_ENABLED = os.environ.get('SSL_ENABLED', 'False') == 'True'
 
 # Flexible SSL settings that work in both development and production
 if SSL_ENABLED:
@@ -399,3 +401,4 @@ SOCIALACCOUNT_PROVIDERS = {
 # Social Auth settings - using consistent variable names
 SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.environ.get("GOOGLE_OAUTH_CLIENT_ID")
 SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET")
+

--- a/artcritique/settings/dev.py
+++ b/artcritique/settings/dev.py
@@ -1,0 +1,5 @@
+from .base import *
+
+DEBUG = True
+ALLOWED_HOSTS = ['*', '.replit.app']
+

--- a/artcritique/settings/prod.py
+++ b/artcritique/settings/prod.py
@@ -1,0 +1,6 @@
+import os
+from .base import *
+
+DEBUG = False
+ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', '').split(',')
+

--- a/artcritique/wsgi.py
+++ b/artcritique/wsgi.py
@@ -11,6 +11,7 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'artcritique.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'artcritique.settings.prod')
 
 application = get_wsgi_application()
+

--- a/main.py
+++ b/main.py
@@ -15,7 +15,8 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # Set deployment environment variables
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'artcritique.settings')
+# Use production settings by default for this entrypoint
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'artcritique.settings.prod')
 os.environ.setdefault('SSL_ENABLED', 'false')
 os.environ.setdefault('HTTP_ONLY', 'true')
 

--- a/manage.py
+++ b/manage.py
@@ -6,7 +6,8 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'artcritique.settings')
+    # Default to development settings; can be overridden by DJANGO_SETTINGS_MODULE
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'artcritique.settings.dev')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
@@ -20,3 +21,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+

--- a/wsgi.py
+++ b/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'artcritique.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'artcritique.settings.prod')
 
 application = get_wsgi_application()


### PR DESCRIPTION
## Summary
- split Django settings into base, dev, and prod modules
- load secrets and hosts from environment variables
- default manage.py to dev settings and main entrypoint to prod
- document environment requirements in `.env.example`

## Testing
- `python -m py_compile artcritique/settings/base.py artcritique/settings/dev.py artcritique/settings/prod.py artcritique/settings/__init__.py manage.py main.py artcritique/asgi.py artcritique/wsgi.py wsgi.py`
- `SECRET_KEY=test python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django==4.2` *(fails: Could not find a version that satisfies the requirement django==4.2)*

------
https://chatgpt.com/codex/tasks/task_e_68bddc22cbc083209371764b3d55767c