### PR TITLE
Document pyproject-based dependency management

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ The project is organized into the following directories:
     - `test-images/`: Test image files
   - `s3/`: S3 storage tests
 
+## Dependency Management
+
+Dependencies are defined in `pyproject.toml` and locked with `uv.lock`.
+Use `uv` to sync and lock dependencies:
+
+```bash
+uv sync      # install dependencies from the lock file
+uv lock      # regenerate uv.lock after modifying dependencies
+```
+
+The legacy `project_requirements.txt` file has been removed.
+
 ## Running the Application
 
 The simplest way to run the application is:

--- a/project_requirements.txt
+++ b/project_requirements.txt
@@ -1,7 +1,0 @@
-django==5.0.2
-djangorestframework==3.16.0
-django-allauth==65.8.0
-django-cors-headers==4.7.0
-psycopg2-binary==2.9.9
-gunicorn==23.0.0
-email-validator==2.1.1


### PR DESCRIPTION
## Summary
- Remove redundant `project_requirements.txt` in favor of `pyproject.toml`
- Document `uv`-based workflow for syncing and locking dependencies
- Regenerate `uv.lock` to ensure versions are aligned

## Testing
- `uv lock`
- `PYTHONPATH=.venv/lib/python3.11/site-packages pytest -q` *(fails: ModuleNotFoundError: No module named 'artcritique')*

------
https://chatgpt.com/codex/tasks/task_e_68bddc1adb548320af4a2d0ed4526452