### PR TITLE
Move permission test into tests suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ The repository is organized into key directories:
 - `docs/` – project documentation
 - `scripts/server/` – server start scripts (e.g., `http_server.py`, `flask_proxy.py`)
 - `scripts/maintenance/` – maintenance utilities (`restart_server.py`, `update_workflow.py`, etc.)
-- `scripts/utility/` – one-off helper scripts (`add_focus_js.py`, `test_permissions.py`, etc.)
+- `scripts/utility/` – one-off helper scripts (e.g., `add_focus_js.py`)
+- `tests/` – automated and manual tests (e.g., authentication and permission tests)
 - `templates/` – HTML templates including `login_page.html`, `signup_page.html`, and `s3_browser.html`
 
 ## Documentation

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -30,6 +30,7 @@ run_auth_tests() {
   print_header "Running Authentication Tests"
   python tests/auth/test_auth_api.py
   python tests/auth/test_auth_image_upload.py
+  python tests/auth/test_permissions.py
 }
 
 # S3 Tests

--- a/tests/auth/README.md
+++ b/tests/auth/README.md
@@ -4,4 +4,5 @@ Tests for authentication functionality.
 ## Files:
 - test_auth_api.py - Tests for authentication API endpoints
 - test_auth_image_upload.py - Tests for authenticated image uploads
+- test_permissions.py - Tests role-based permission classes
 

--- a/tests/auth/test_permissions.py
+++ b/tests/auth/test_permissions.py
@@ -7,7 +7,7 @@ This script tests the role-based permissions by:
 3. Printing the results to verify permissions are working
 
 Usage:
-    python scripts/utility/test_permissions.py
+    python tests/auth/test_permissions.py
 """
 
 import os
@@ -168,3 +168,4 @@ def test_permissions():
 
 if __name__ == "__main__":
     test_permissions()
+


### PR DESCRIPTION
## Summary
- move permission test script into `tests/auth`
- register permission test in the auth test runner
- document test location in repository docs

## Testing
- `python tests/auth/test_permissions.py` *(fails: ModuleNotFoundError: No module named 'django')*
- `pre-commit run --files tests/auth/test_permissions.py scripts/run_all_tests.sh tests/auth/README.md README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be5f22e89883208f8471844df19d39